### PR TITLE
Fix gcc10 compilation

### DIFF
--- a/video_out_sdl.c
+++ b/video_out_sdl.c
@@ -314,10 +314,10 @@ void handle_event(SDL_Event event) {
 unsigned char buf0[MAXWIDTH*MAXHEIGHT*3];
 
 vo_instance_t * instance;
-vo_setup_result_t result;
 
 void vo_init(int width, int height, char *title)
 {
+  vo_setup_result_t result;
   instance = vo_sdl_open();
   SDL_WM_SetCaption(title, "comskip");
   sdl_setup(instance, width, height, width, height, &result);


### PR DESCRIPTION
Error reported (see also #121 ) :
```
/usr/bin/ld: comskip_gui-video_out_sdl.o:./video_out_sdl.c:309: multiple definition of `result'; ccextratorwin/comskip_gui-general_loop.o:./ccextratorwin/general_loop.c:20: first defined here
```

So, moving result variable ( video_out_sdl.c ) inside the only function that uses it.